### PR TITLE
Allow updating of file stores

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,6 +13,7 @@ RoxygenNote: 7.2.1
 URL: https://github.com/mrc-ide/outpack.orderly
 BugReports: https://github.com/mrc-ide/outpack.orderly/issues
 Imports:
+    fs,
     jsonlite,
     jsonvalidate,
     orderly,

--- a/R/store.R
+++ b/R/store.R
@@ -1,0 +1,23 @@
+## This will be useful for copying over files, we can use this in the
+## initial migration too. I don't think that it wants to go into the
+## core outpack implementation though as we probably do not want to
+## encourage use of hard links...
+file_store_link <- R6::R6Class(
+  "file_store_link",
+  cloneable = FALSE,
+  inherit = outpack:::file_store,
+
+  public = list(
+    put = function(src, hash, move = FALSE) {
+      if (move) {
+        stop("Can't move files into a link store")
+      }
+      outpack:::hash_validate(src, hash)
+      dst <- self$filename(hash)
+      if (!fs::file_exists(dst)) {
+        fs::dir_create(dirname(dst))
+        fs::link_create(src, dst, symbolic = FALSE)
+      }
+      invisible(hash)
+    }
+  ))

--- a/man/orderly2outpack.Rd
+++ b/man/orderly2outpack.Rd
@@ -4,7 +4,7 @@
 \alias{orderly2outpack}
 \title{Migrate orderly to outpack}
 \usage{
-orderly2outpack(src, dest)
+orderly2outpack(src, dest, link = FALSE)
 }
 \arguments{
 \item{src}{Path to the orderly archive to migrate. This must be
@@ -15,6 +15,15 @@ pulls)}
 will be created with no user-visible archive directory, with a
 file store, and requiring a full tree (i.e., in a suitable
 configuration to use as an upstream source).}
+
+\item{link}{Logical, indicating if the file store should be hard
+links to the existing orderly archive, rather than copies of the
+files. Doing this carries some risk and constraints: must be on
+the same file system, can't make files readonly, changes
+propagated both ways. As a result, only do this where you are
+confident that nothing will alter files in the source archive!
+The use case here is in continually migrating an orderly
+repository.}
 }
 \value{
 The path to the newly created archive

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -89,3 +89,36 @@ test_that("test weird special cases", {
   expect_identical(root_cmp$metadata(id2, full = TRUE),
                    root_res$metadata(id2, full = TRUE))
 })
+
+
+test_that("can create link-based file store", {
+  src <- orderly_demo_archive()
+  dst <- suppressMessages(orderly2outpack(src, tempfile(), link = TRUE))
+
+  path_files <- file.path(dst, ".outpack", "files")
+  files <- dir(path_files, recursive = TRUE, include.dirs = FALSE,
+               full.names = TRUE)
+  info <- fs::file_info(files)
+  expect_true(all(info$hard_links == 2))
+})
+
+
+test_that("can update archive", {
+  src <- orderly_demo_archive()
+  dst <- suppressMessages(orderly2outpack(src, tempfile(), link = TRUE))
+
+  id <- suppressMessages(
+    orderly::orderly_run("minimal", root = src, echo = FALSE))
+  suppressMessages(orderly::orderly_commit(id, root = src))
+
+  root <- outpack::outpack_root_open(dst, locate = FALSE)
+
+  expect_false(id %in% names(root$index(TRUE)$metadata))
+
+  expect_equal(
+    suppressMessages(orderly2outpack(src, dst, link = TRUE)),
+    dst)
+
+  expect_true(id %in% names(root$index(TRUE)$metadata))
+  expect_true(id %in% root$index(TRUE)$unpacked$packet)
+})

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -16,8 +16,9 @@ test_that("migration destination must not yet exist", {
   src <- orderly_demo_archive()
   dest <- tempfile()
   dir.create(dest)
+  file.create(file.path(dest, "anything"))
   expect_error(orderly2outpack(src, dest),
-               "Destination already exists")
+               "Destination directory is not a bare outpack destination")
 })
 
 

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1,0 +1,33 @@
+test_that("can create link-based file store", {
+  tmp <- tempfile()
+  obj <- file_store_link$new(tmp)
+  expect_equal(obj$list(), character(0))
+})
+
+
+test_that("can add files to a link based store", {
+  skip_on_os("windows")
+  tmp <- tempfile()
+  dir.create(tmp)
+  p <- file.path(tmp, "a")
+  saveRDS(runif(10), p)
+  h <- outpack:::hash_file(p)
+  obj <- file_store_link$new(tempfile())
+  expect_equal(obj$put(p, h), h)
+  expect_true(file.exists(obj$filename(h)))
+  info <- fs::file_info(obj$filename(h))
+  expect_identical(info$inode, fs::file_info(p)$inode)
+  expect_equal(info$hard_links, 2)
+})
+
+
+test_that("prevent use of 'move' argument with link store", {
+  skip_on_os("windows")
+  tmp <- tempfile()
+  dir.create(tmp)
+  p <- file.path(tmp, "a")
+  saveRDS(runif(10), p)
+  h <- outpack:::hash_file(p)
+  obj <- file_store_link$new(tempfile())
+  expect_error((obj$put(p, h, TRUE), "Can't move files into a link store")
+})

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -1,4 +1,5 @@
 test_that("can create link-based file store", {
+  skip_on_os("windows")
   tmp <- tempfile()
   obj <- file_store_link$new(tmp)
   expect_equal(obj$list(), character(0))

--- a/tests/testthat/test-store.R
+++ b/tests/testthat/test-store.R
@@ -30,5 +30,5 @@ test_that("prevent use of 'move' argument with link store", {
   saveRDS(runif(10), p)
   h <- outpack:::hash_file(p)
   obj <- file_store_link$new(tempfile())
-  expect_error((obj$put(p, h, TRUE), "Can't move files into a link store")
+  expect_error(obj$put(p, h, TRUE), "Can't move files into a link store")
 })


### PR DESCRIPTION
This	makes two changes to allow updating of a migrated orderly archive:

* use a link-based file store; this means that we don't require two full copies of the data always (which would be problematic on montagu)
* allow the destination to exist, so long as it looks like something we could migrate into