### PR TITLE
fobid concurrent jobs

### DIFF
--- a/docker/schedule.yml
+++ b/docker/schedule.yml
@@ -9,3 +9,4 @@ jobs:
       producesStdout: false
       nonzeroReturn: true
       always: false
+    concurrencyPolicy: Forbid


### PR DESCRIPTION
The job is taking too long and starting over again, running concurrently, causing conflicts.