### PR TITLE
Small fixes after drift in orderly2/orderly.db

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack.orderly
 Title: Orderly to outpack metadata migration
-Version: 0.1.1
+Version: 0.1.2
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",
@@ -19,7 +19,7 @@ Imports:
     jsonvalidate,
     orderly1 (>= 1.7.0),
     orderly2 (>= 1.99.2),
-    orderly.db,
+    orderly.db (>= 0.1.2),
     withr
 Suggests:
     markdown,

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -33,7 +33,6 @@ orderly2outpack <- function(src, dest, link = FALSE) {
     stop("Destination directory is not a bare outpack destination")
   }
   orderly2::orderly_init(dest,
-                         logging_console = FALSE,
                          path_archive = NULL,
                          use_file_store = TRUE,
                          require_complete_tree = TRUE)

--- a/R/src.R
+++ b/R/src.R
@@ -68,7 +68,7 @@ orderly2outpack_src <- function(path, delete_yml = FALSE, strict = FALSE,
     fs::file_move(file.path(path, global_path), file.path(path, "shared"))
   }
 
-  orderly2::orderly_init(path, logging_console = FALSE)
+  orderly2::orderly_init(path)
 
   invisible(path)
 }
@@ -276,17 +276,17 @@ src_migrate_db_data <- function(cfg, dat) {
   if (is.null(dat$data)) {
     return(NULL)
   }
-  fmt <- "orderly.db::orderly_db_query(\n  %s)"
+  fmt <- "%s <- orderly.db::orderly_db_query(\n  %s)"
   ret <- character(0)
   for (i in names(dat$data)) {
     x <- dat$data[[i]]
-    args <- c(query = x$query, as = i)
+    args <- c(query = x$query)
     if (!is.null(x$database)) {
       args[["database"]] <- x$database
     }
     args_str <- paste(sprintf('%s = "%s"', names(args), unname(args)),
                       collapse = ",\n  ")
-    ret <- c(ret, sprintf(fmt, args_str))
+    ret <- c(ret, sprintf(fmt, i, args_str))
   }
   ret
 }
@@ -298,13 +298,13 @@ src_migrate_db_connection <- function(cfg, dat) {
   }
 
   ret <- character(0)
-  fmt <- "orderly.db::orderly_db_connection(%s)"
+  fmt <- "%s <- orderly.db::orderly_db_connection(%s)"
   for (i in names(dat$connection)) {
     ## TODO: some control parameter here to tune 'instance' or not.
-    args <- c(as = i, database = dat$connection[[i]])
+    args <- c(database = dat$connection[[i]])
     args_str <- paste(sprintf('%s = "%s"', names(args), unname(args)),
                       collapse = ", ")
-    ret <- c(ret, sprintf(fmt, args_str))
+    ret <- c(ret, sprintf(fmt, i, args_str))
   }
   ret
 }

--- a/tests/testthat/test-src.R
+++ b/tests/testthat/test-src.R
@@ -1,6 +1,6 @@
 test_that("Can migrate orderly demo directory", {
   path <- orderly_demo_src()
-  orderly2outpack_src(path, delete_yml = TRUE, strict = TRUE)
+  suppressMessages(orderly2outpack_src(path, delete_yml = TRUE, strict = TRUE))
 
   dat <- orderly1:::read_demo_yml(path)
   for (i in seq_along(dat)) {
@@ -9,8 +9,9 @@ test_that("Can migrate orderly demo directory", {
       withr::with_dir(path, x$before())
     }
     env <- new.env(parent = .GlobalEnv)
-    dat[[i]]$id <- orderly2::orderly_run(x$name, x$parameters, envir = env,
-                                         root = path)
+    expect_no_error(suppressMessages(
+      dat[[i]]$id <- orderly2::orderly_run(x$name, x$parameters, envir = env,
+                                           root = path, echo = FALSE)))
   }
 })
 
@@ -46,8 +47,8 @@ test_that("can preserve original files after migration", {
   kept <- c("orderly_config.yml.orig", keep[-1])
   h1 <- withr::with_dir(path1, tools::md5sum(sub("\\.orig$", "", keep)))
 
-  orderly2outpack_src(path1, delete_yml = TRUE)
-  orderly2outpack_src(path2, delete_yml = FALSE)
+  suppressMessages(orderly2outpack_src(path1, delete_yml = TRUE))
+  suppressMessages(orderly2outpack_src(path2, delete_yml = FALSE))
   files1 <- dir(path1, recursive = TRUE, all.files = TRUE, no.. = TRUE,
                 include.dirs = FALSE)
   files2 <- dir(path2, recursive = TRUE, all.files = TRUE, no.. = TRUE,
@@ -63,7 +64,7 @@ test_that("can preserve original files after migration", {
 test_that("can add strict mode", {
   path <- orderly_demo_src()
   nms <- orderly1::orderly_list(path)
-  orderly2outpack_src(path, delete_yml = TRUE, strict = TRUE)
+  suppressMessages(orderly2outpack_src(path, delete_yml = TRUE, strict = TRUE))
   str <- vapply(file.path(path, "src", nms, "orderly.R"),
                 function(p) readLines(p, n = 1), "",
                 USE.NAMES = FALSE)
@@ -74,7 +75,7 @@ test_that("can add strict mode", {
 test_that("can not add strict mode", {
   path <- orderly_demo_src()
   nms <- orderly1::orderly_list(path)
-  orderly2outpack_src(path, delete_yml = TRUE, strict = FALSE)
+  suppressMessages(orderly2outpack_src(path, delete_yml = TRUE, strict = FALSE))
   str <- "orderly2::orderly_strict_mode()"
   expect_false(
     any(vapply(file.path(path, "src", nms, "orderly.R"),


### PR DESCRIPTION
Nothing major here:

* We changed orderly.db to use assignment for queries and connection, so update generated code
* The console logging option for orderly_init has gone
* Quieten down output within tests so we can actually see what the test output says