### PR TITLE
Add orderly db metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack.orderly
 Title: Orderly to outpack metadata migration
-Version: 0.1.2
+Version: 0.1.3
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -147,9 +147,7 @@ orderly_metadata_to_outpack <- function(path, hash_algorithm) {
 
   custom <- data$meta$extra_fields
   custom <- custom[!vlapply(custom, function(x) is.null(x) || is.na(x))]
-  if (length(custom) == 0) {
-    custom <- NULL
-  } else {
+  if (!is.null(custom)) {
     custom <- lapply(custom, scalar)
   }
 

--- a/R/src.R
+++ b/R/src.R
@@ -280,7 +280,7 @@ src_migrate_db_data <- function(cfg, dat) {
   ret <- character(0)
   for (i in names(dat$data)) {
     x <- dat$data[[i]]
-    args <- c(query = x$query)
+    args <- c(query = x$query, name = i)
     if (!is.null(x$database)) {
       args[["database"]] <- x$database
     }

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -134,3 +134,52 @@ test_that("can update archive", {
                                   root = dst)
   expect_true(id %in% ids)
 })
+
+
+test_that("dependency migration", {
+  depends <- data.frame(
+    id = "a",
+    index = 1,
+    name = "foo",
+    id_requested = "latest",
+    as = "here.csv",
+    filename = "there.csv")
+  expect_equal(
+    archive_migrate_depends(depends, NULL),
+    list(list(packet = "a",
+              query = 'latest(name == "foo")',
+              files = data_frame(here = "here.csv", there = "there.csv"))))
+})
+
+
+test_that("dependency migration with fixed id", {
+  depends <- data.frame(
+    id = "a",
+    index = 1,
+    name = "foo",
+    id_requested = "20240202-111943-fa53e980",
+    as = "here.csv",
+    filename = "there.csv")
+  expect_equal(
+    archive_migrate_depends(depends, NULL),
+    list(list(packet = "a",
+              query = "20240202-111943-fa53e980",
+              files = data_frame(here = "here.csv", there = "there.csv"))))
+})
+
+
+test_that("dependency migration with fancy query", {
+  depends <- data.frame(
+    id = "a",
+    index = 1,
+    name = "foo",
+    id_requested = "latest(x == parameter:y)",
+    as = "here.csv",
+    filename = "there.csv")
+  parameters <- list(x = 1)
+  expect_equal(
+    archive_migrate_depends(depends, "x"),
+    list(list(packet = "a",
+              query = 'latest(this:x == parameter:y && name == "foo")',
+              files = data_frame(here = "here.csv", there = "there.csv"))))
+})

--- a/tests/testthat/test-zzz-integration.R
+++ b/tests/testthat/test-zzz-integration.R
@@ -1,0 +1,59 @@
+test_that("migrating source then archive is same as archive then source", {
+  src1 <- orderly_demo_archive()
+  suppressMessages(dst1 <- orderly2outpack(src1, tempfile()))
+
+  src2 <- orderly_demo_src()
+  suppressMessages(orderly2outpack_src(src2, delete_yml = TRUE, strict = TRUE))
+  dat <- orderly1:::read_demo_yml(src2)
+  for (i in seq_along(dat)) {
+    x <- dat[[i]]
+    if (!is.null(x$before)) {
+      withr::with_dir(src2, x$before())
+    }
+    env <- new.env(parent = .GlobalEnv)
+    expect_no_error(suppressMessages(
+      dat[[i]]$id <- orderly2::orderly_run(x$name, x$parameters, envir = env,
+                                           root = src2, echo = FALSE)))
+  }
+
+  ## Need to copy over configuration to the archive migration, because
+  ## otherwise we don't get custom deserialisers for orderly.db, which
+  ## is a bit annoying.
+  file.copy(file.path(src2, "orderly_config.yml"),
+            file.path(dst1, "orderly_config.yml"), overwrite = TRUE)
+
+  id1 <- sort(dir(file.path(dst1, ".outpack", "metadata")))
+  id2 <- vcapply(dat, "[[", "id")
+  expect_length(id2, length(id1))
+
+  for (i in seq_along(id1)) {
+    meta1 <- orderly2::orderly_metadata(id1[[i]], root = dst1)
+    meta2 <- orderly2::orderly_metadata(id2[[i]], root = src2)
+    expect_setequal(names(meta1), names(meta2))
+    expect_equal(meta1$schema_version, meta2$schema_version)
+    expect_equal(meta1$name, meta2$name)
+    expect_equal(meta1$parameters, meta2$parameters)
+
+    ## Can't check id, files, time as we don't expect these to be the
+    ## same.  The git cases are empty, and depends needs some work to
+    ## remap ids.
+    depends2 <- meta2$depends
+    depends2$packet <- id1[match(depends2$packet, id2)]
+    expect_equal(meta1$depends, depends2)
+
+    expect_equal(meta1$git, meta2$git)
+
+    ## custom metadata
+    expect_setequal(names(meta1$custom), names(meta2$custom))
+
+    orderly1 <- meta1$custom$orderly
+    orderly2 <- meta2$custom$orderly
+    expect_setequal(names(orderly1), names(orderly2))
+    expect_equal(orderly1$artefacts, orderly2$artefacts)
+    expect_equal(orderly1$shared, orderly2$shared)
+    expect_equal(orderly1$description, orderly2$description)
+    ## Can't check role or session; these are expected to differ.
+
+    expect_equal(meta1$custom$orderly.db, meta2$custom$orderly.db)
+  }
+})


### PR DESCRIPTION
This PR migrates orderly db metadata from existing packets.

Also includes a test that shows that if we run orderly1 and migrate we get the same (effective) metadata as running migrate on the source then orderly2
