### PR TITLE
Add test and fix for report which uses multiple files from same dependency

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -21,3 +21,5 @@
 ^\.covrignore$
 ^\.github$
 \.*gcov$
+^.*\.Rproj$
+^\.Rproj\.user$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: outpack.orderly
 Title: Orderly to outpack metadata migration
-Version: 0.1.3
+Version: 0.1.4
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Imperial College of Science, Technology and Medicine",

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,8 @@ Imports:
     orderly1 (>= 1.7.0),
     orderly2 (>= 1.99.2),
     orderly.db (>= 0.1.2),
-    withr
+    withr,
+    yaml
 Suggests:
     markdown,
     rmarkdown,

--- a/R/migrate.R
+++ b/R/migrate.R
@@ -249,14 +249,14 @@ archive_migrate_depends <- function(depends, parameters) {
   }
   ## Seen in rtm_incoming_serology/20200603-204022-70b8bfa5
   if (is.null(depends$index)) {
-    depends$index <- as.integer(factor(depends$id))
+    depends$index <- as.integer(factor(paste0(depends$id, depends$id_requested)))
   }
   unname(lapply(
     split(depends, depends$index), function(x) {
-      if (x$id_requested %in% c("latest", "latest()")) {
-        query <- sprintf('latest(name == "%s")', x$name)
-      } else if (grepl("latest\\(", x$id_requested)) {
-        str <- sub(")$", sprintf(' && name == "%s")', x$name), x$id_requested)
+      if (x$id_requested[[1]] %in% c("latest", "latest()")) {
+        query <- sprintf('latest(name == "%s")', x$name[[1]])
+      } else if (grepl("latest\\(", x$id_requested[[1]])) {
+        str <- sub(")$", sprintf(' && name == "%s")', x$name[[1]]), x$id_requested[[1]])
         query <- src_migrate_query(str, parameters)
       } else {
         query <- x$id_requested[[1]]

--- a/outpack.orderly.Rproj
+++ b/outpack.orderly.Rproj
@@ -1,0 +1,20 @@
+Version: 1.0
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX
+
+AutoAppendNewline: Yes
+StripTrailingWhitespace: Yes
+
+BuildType: Package
+PackageUseDevtools: Yes
+PackageInstallArgs: --no-multiarch --with-keep.source

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -212,8 +212,8 @@ test_that("can migrate when archive has more than 1 dependency from 1 report", {
   writeLines(multi_dependency_script, file.path(multi_dependency, "script.R"))
   yaml::write_yaml(multi_dependency_yml,
                    file.path(multi_dependency, "orderly.yml"))
-  x <- orderly::orderly_run("multi-dependency", root = src)
-  orderly::orderly_commit(x, root = src)
+  x <- orderly1::orderly_run("multi-dependency", root = src)
+  orderly1::orderly_commit(x, root = src)
 
   msg <- testthat::capture_messages(dst <- orderly2outpack(src, tempfile()))
   expect_true(file.exists(dst))

--- a/tests/testthat/test-migrate.R
+++ b/tests/testthat/test-migrate.R
@@ -183,3 +183,45 @@ test_that("dependency migration with fancy query", {
               query = 'latest(this:x == parameter:y && name == "foo")',
               files = data_frame(here = "here.csv", there = "there.csv"))))
 })
+
+
+test_that("can migrate when archive has more than 1 dependency from 1 report", {
+  src <- orderly_demo_archive()
+  multi_dependency_yml <- list(script = "script.R",
+                               depends = list(
+                                 "multi-artefact" = list(
+                                   id = "latest",
+                                   use = list("all.csv" = "all.csv",
+                                              "subset.csv" = "subset.csv")
+                                 )
+                               ),
+                               artefacts = list(list(
+                                 data = list(
+                                   description = "some data",
+                                   filenames = "rows.rds"
+                                 )
+                               )),
+                               requester = "Joe Bloggs",
+                               author = "Joe Bloggs")
+  multi_dependency_script <- c("x <- read.csv('all.csv')",
+                               "y <- read.csv('subset.csv')",
+                               "z <- nrow(x) + nrow(y)",
+                               "saveRDS(z, 'rows.rds')")
+  multi_dependency <- file.path(src, "src", "multi-dependency")
+  dir.create(multi_dependency)
+  writeLines(multi_dependency_script, file.path(multi_dependency, "script.R"))
+  yaml::write_yaml(multi_dependency_yml,
+                   file.path(multi_dependency, "orderly.yml"))
+  x <- orderly::orderly_run("multi-dependency", root = src)
+  orderly::orderly_commit(x, root = src)
+
+  msg <- testthat::capture_messages(dst <- orderly2outpack(src, tempfile()))
+  expect_true(file.exists(dst))
+  expect_equal(dir(dst, all.files = TRUE, no.. = TRUE),
+               c(".outpack", "orderly_config.yml"))
+  expect_true(file.exists(file.path(dst, ".outpack")))
+
+  ids <- orderly2::orderly_search(NULL, options = list(location = "local"),
+                                  root = dst)
+  expect_setequal(ids, orderly1::orderly_list_archive(src)$id)
+})


### PR DESCRIPTION
Spotted a new issue when migrating Debebe's orderly. If someone is pulling in 2 files from the same dependency, we are not handling this case in the migration.

I've added a test which recreates the problem and have fixed the impl